### PR TITLE
7 - reservation cooldown when reserving from resource page

### DIFF
--- a/app/pages/resource/reservation-calendar/reservationCalendarSelector.js
+++ b/app/pages/resource/reservation-calendar/reservationCalendarSelector.js
@@ -79,7 +79,9 @@ const timeSlotsSelector = createSelector(
     const { closes, opens } = getOpeningHours(resource);
     const period = resource.slotSize || DEFAULT_SLOT_SIZE;
     const reservations = getOpenReservations(resource);
-    const timeSlots = getTimeSlots(opens, closes, period, reservations, reservationsToEdit);
+    const timeSlots = getTimeSlots(
+      opens, closes, period, reservations, reservationsToEdit, resource.cooldown
+    );
     if (timeSlots.length) {
       return timeSlots;
     }

--- a/app/pages/resource/reservation-calendar/time-slots/TimeSlot.js
+++ b/app/pages/resource/reservation-calendar/time-slots/TimeSlot.js
@@ -36,7 +36,7 @@ class TimeSlot extends PureComponent {
 
   static getDerivedStateFromProps(prop) {
     const {
-      slot, resource, isDisabled, isSelectable, selected, isLoggedIn
+      slot, resource, isAdmin, isDisabled, isSelectable, selected, isLoggedIn
     } = prop;
     const isPast = new Date(slot.end) < new Date();
     const isReservable = (resource.reservableAfter
@@ -46,7 +46,8 @@ class TimeSlot extends PureComponent {
       || (!isSelectable && !selected)
       || !resource.userPermissions.canMakeReservations
       || isReservable
-      || (!slot.editing && (slot.reserved || isPast));
+      || (!slot.editing && (slot.reserved || isPast))
+      || (slot.onCooldown && !isAdmin);
 
     return {
       disabled,

--- a/app/pages/resource/reservation-calendar/time-slots/TimeSlot.js
+++ b/app/pages/resource/reservation-calendar/time-slots/TimeSlot.js
@@ -189,7 +189,8 @@ class TimeSlot extends PureComponent {
     const { disabled, isPast } = this.state;
 
     const reservation = slot.reservation;
-    const isOwnReservation = reservation && reservation.isOwn;
+    const isOwnReservation = reservation && reservation.isOwn && slot.reserved;
+    const isCooldown = slot.onCooldown;
     const start = new Date(slot.start);
     const startTime = `${padLeft(start.getHours())}:${padLeft(start.getMinutes())}`;
 
@@ -206,6 +207,7 @@ class TimeSlot extends PureComponent {
           'app-TimeSlot--reserved': slot.reserved,
           'app-TimeSlot--selected': selected,
           'app-TimeSlot--highlight': isHighlighted,
+          'app-TimeSlot--cooldown': isCooldown,
         })}
         ref={this.timeSlotRef}
       >

--- a/app/pages/resource/reservation-calendar/time-slots/TimeSlot.js
+++ b/app/pages/resource/reservation-calendar/time-slots/TimeSlot.js
@@ -193,6 +193,12 @@ class TimeSlot extends PureComponent {
     const isCooldown = slot.onCooldown;
     const start = new Date(slot.start);
     const startTime = `${padLeft(start.getHours())}:${padLeft(start.getMinutes())}`;
+    const showCooldown = isAdmin
+      && isCooldown
+      && !isPast
+      && !selected
+      && !isHighlighted
+      && !disabled;
 
     return (
       <div
@@ -218,7 +224,7 @@ class TimeSlot extends PureComponent {
           onMouseLeave={() => !disabled && onMouseLeave()}
           type="button"
         >
-          <span aria-hidden="true" className="app-TimeSlot__icon" />
+          <span aria-hidden="true" className={`app-TimeSlot__icon${showCooldown ? ' cooldown' : ''}`} />
           <time className="app-TimeSlot__time" dateTime={slot.asISOString}>{startTime}</time>
           <span
             aria-label={this.getSelectButtonStatusLabel(

--- a/app/pages/resource/reservation-calendar/time-slots/TimeSlot.spec.js
+++ b/app/pages/resource/reservation-calendar/time-slots/TimeSlot.spec.js
@@ -45,6 +45,34 @@ describe('pages/resource/reservation-calendar/time-slots/TimeSlot', () => {
     expect(icon.prop('aria-hidden')).toBe('true');
   });
 
+  test('renders app-TimeSlot__icon cooldown when isAdmin', () => {
+    const slotWithCooldown = TimeSlotFixture.build({ onCooldown: true });
+    const wrapper = getWrapper({
+      isAdmin: true,
+      slot: slotWithCooldown,
+      isPast: false,
+      selected: false,
+      isHighlighted: false,
+      disabled: false,
+    });
+    const icon = wrapper.find('button.app-TimeSlot__action').find('span').first();
+    expect(icon.prop('className')).toBe('app-TimeSlot__icon cooldown');
+  });
+
+  test('does not render app-TimeSlot__icon cooldown when not isAdmin', () => {
+    const slotWithCooldown = TimeSlotFixture.build({ onCooldown: true });
+    const wrapper = getWrapper({
+      isAdmin: false,
+      slot: slotWithCooldown,
+      isPast: false,
+      selected: false,
+      isHighlighted: false,
+      disabled: false,
+    });
+    const icon = wrapper.find('button.app-TimeSlot__action').find('span').first();
+    expect(icon.prop('className')).toBe('app-TimeSlot__icon');
+  });
+
   test('renders app-TimeSlot__status', () => {
     const icon = getWrapper().find('.app-TimeSlot__icon');
     expect(icon).toHaveLength(1);

--- a/app/pages/resource/reservation-calendar/time-slots/TimeSlots.js
+++ b/app/pages/resource/reservation-calendar/time-slots/TimeSlots.js
@@ -218,7 +218,7 @@ class TimeSlots extends Component {
 
     const isFirstSelected = utils.isFirstSelected(slot, selected);
     const shouldShowReservationPopover = hoveredTimeSlot
-    && isFirstSelected && !isHoveredSlotSelected;
+      && isFirstSelected && !isHoveredSlotSelected;
 
     const isHighlighted = utils.isHighlighted(slot, selected, hoveredTimeSlot);
     const resBegin = this.getReservationBegin();
@@ -264,9 +264,7 @@ class TimeSlots extends Component {
       >
         {timeSlot}
       </ReservationPopover>
-    ) : (
-      timeSlot
-    );
+    ) : (timeSlot);
   };
 
   render() {

--- a/app/pages/resource/reservation-calendar/time-slots/_time-slots.scss
+++ b/app/pages/resource/reservation-calendar/time-slots/_time-slots.scss
@@ -70,6 +70,10 @@
       }
     }
 
+    &--cooldown.app-TimeSlot--is-admin {
+      background-color: lightpink;
+    }
+
     &--disabled {
       &:hover {
         cursor: not-allowed;

--- a/app/pages/resource/reservation-calendar/time-slots/_time-slots.scss
+++ b/app/pages/resource/reservation-calendar/time-slots/_time-slots.scss
@@ -72,18 +72,16 @@
 
     // only in use when logged in as admin and resource has cooldown.
     &--cooldown.app-TimeSlot--is-admin:not(.app-TimeSlot--past) {
-      background: repeating-linear-gradient(
-        45deg,
-        $silver,
-        $silver 10px,
-        $gray-light 10px,
-        $gray-light 15px
-      );
-      &:hover:not(.app-TimeSlot--disabled) {
-        background: $dark-gray;
-        color: $white;
-        .app-TimeSlot__time {
-          color: white;
+      .app-TimeSlot__action > .app-TimeSlot__icon {
+        font-family: 'Segoe UI Symbol';
+        vertical-align: inherit;
+        &.cooldown::before {
+          content: '\231B';
+        }
+      }
+      &:hover{
+        .app-TimeSlot__action > .app-TimeSlot__icon {
+          color: $white;
         }
       }
     }

--- a/app/pages/resource/reservation-calendar/time-slots/_time-slots.scss
+++ b/app/pages/resource/reservation-calendar/time-slots/_time-slots.scss
@@ -70,8 +70,22 @@
       }
     }
 
-    &--cooldown.app-TimeSlot--is-admin {
-      background-color: lightpink;
+    // only in use when logged in as admin and resource has cooldown.
+    &--cooldown.app-TimeSlot--is-admin:not(.app-TimeSlot--past) {
+      background: repeating-linear-gradient(
+        45deg,
+        $silver,
+        $silver 10px,
+        $gray-light 10px,
+        $gray-light 15px
+      );
+      &:hover:not(.app-TimeSlot--disabled) {
+        background: $dark-gray;
+        color: $white;
+        .app-TimeSlot__time {
+          color: white;
+        }
+      }
     }
 
     &--disabled {

--- a/app/pages/resource/reservation-calendar/utils.js
+++ b/app/pages/resource/reservation-calendar/utils.js
@@ -66,6 +66,9 @@ function isSlotSelectable(slot, selected, resource, lastSelectableFound, isAdmin
   if ((!slot.editing && slot.reserved) || lastSelectableFound) {
     return false;
   }
+  if (slot.onCooldown && !isAdmin) {
+    return false;
+  }
   const firstSelected = getBeginOfSelection(selected);
   if (!isAdmin && resource.maxPeriod) {
     const durationParts = resource.maxPeriod.split(':');

--- a/app/pages/resource/reservation-calendar/utils.js
+++ b/app/pages/resource/reservation-calendar/utils.js
@@ -69,6 +69,7 @@ function isSlotSelectable(slot, selected, resource, lastSelectableFound, isAdmin
   if (slot.onCooldown && !isAdmin) {
     return false;
   }
+
   const firstSelected = getBeginOfSelection(selected);
   if (!isAdmin && resource.maxPeriod) {
     const durationParts = resource.maxPeriod.split(':');

--- a/app/utils/__tests__/timeUtils.spec.js
+++ b/app/utils/__tests__/timeUtils.spec.js
@@ -539,6 +539,32 @@ describe('Utils: timeUtils', () => {
         });
       });
     });
+    describe('slot onCooldown property', () => {
+      const start = '2015-10-09T08:00:00+03:00';
+      const end = '2015-10-09T13:00:00+03:00';
+      const period = '01:00:00';
+      const reservations = [
+        {
+          begin: '2015-10-09T10:00:00+03:00',
+          end: '2015-10-09T11:00:00+03:00',
+        },
+      ];
+      test('is always false when cooldown is not set or it is 0', () => {
+        const slots = getTimeSlots(start, end, period, reservations);
+        slots.forEach((slot) => {
+          expect(slot.onCooldown).toBe(false);
+        });
+      });
+      test('is true for slots before and after reservations when cooldown is set', () => {
+        const cooldown = '1:00:00';
+        const slots = getTimeSlots(start, end, period, reservations, [], cooldown);
+        expect(slots[0].onCooldown).toBe(false);
+        expect(slots[1].onCooldown).toBe(true);
+        expect(slots[2].onCooldown).toBe(false);
+        expect(slots[3].onCooldown).toBe(true);
+        expect(slots[4].onCooldown).toBe(false);
+      });
+    });
   });
 
   describe('isPastDate', () => {

--- a/app/utils/__tests__/timeUtils.spec.js
+++ b/app/utils/__tests__/timeUtils.spec.js
@@ -549,6 +549,24 @@ describe('Utils: timeUtils', () => {
           end: '2015-10-09T11:00:00+03:00',
         },
       ];
+      let twoReservations = [
+        {
+          begin: '2015-10-09T09:00:00+03:00',
+          end: '2015-10-09T10:00:00+03:00',
+          isOwn: false,
+        },
+        {
+          begin: '2015-10-09T11:00:00+03:00',
+          end: '2015-10-09T12:00:00+03:00',
+          isOwn: true,
+        }
+      ];
+      const reservationsToEdit = [
+        {
+          begin: '2015-10-09T08:30:00+03:00',
+          end: '2015-10-09T09:30:00+03:00',
+        },
+      ];
       test('is always false when cooldown is not set or it is 0', () => {
         const slots = getTimeSlots(start, end, period, reservations);
         slots.forEach((slot) => {
@@ -562,6 +580,69 @@ describe('Utils: timeUtils', () => {
         expect(slots[1].onCooldown).toBe(true);
         expect(slots[2].onCooldown).toBe(false);
         expect(slots[3].onCooldown).toBe(true);
+        expect(slots[4].onCooldown).toBe(false);
+      });
+
+      test('is true when slot is shared by two reservations', () => {
+        const cooldown = '1:00:00';
+        const slots = getTimeSlots(
+          start,
+          end,
+          period,
+          twoReservations,
+          [],
+          cooldown
+        );
+        expect(slots[0].onCooldown).toBe(true);
+        expect(slots[1].onCooldown).toBe(false);
+        expect(slots[2].onCooldown).toBe(true);
+        expect(slots[3].onCooldown).toBe(false);
+        expect(slots[4].onCooldown).toBe(true);
+      });
+
+      test('is true when slot is shared by two reservations when editing', () => {
+        const cooldown = '1:00:00';
+        const slots = getTimeSlots(
+          start,
+          end,
+          period,
+          twoReservations,
+          reservationsToEdit,
+          cooldown
+        );
+        expect(slots[0].onCooldown).toBe(true);
+        expect(slots[1].onCooldown).toBe(false);
+        expect(slots[2].onCooldown).toBe(true);
+        expect(slots[3].onCooldown).toBe(false);
+        expect(slots[4].onCooldown).toBe(false);
+      });
+
+      test('is true when editing with two reservations, !isOwn reservations cooldown remains', () => {
+        const cooldown = '1:00:00';
+        twoReservations = [
+          {
+            begin: '2015-10-09T08:00:00+03:00',
+            end: '2015-10-09T09:00:00+03:00',
+            isOwn: false,
+          },
+          {
+            begin: '2015-10-09T12:00:00+03:00',
+            end: '2015-10-09T13:00:00+03:00',
+            isOwn: true,
+          }
+        ];
+        const slots = getTimeSlots(
+          start,
+          end,
+          period,
+          twoReservations,
+          reservationsToEdit,
+          cooldown
+        );
+        expect(slots[0].onCooldown).toBe(false);
+        expect(slots[1].onCooldown).toBe(true);
+        expect(slots[2].onCooldown).toBe(false);
+        expect(slots[3].onCooldown).toBe(false);
         expect(slots[4].onCooldown).toBe(false);
       });
     });

--- a/app/utils/fixtures/TimeSlot.js
+++ b/app/utils/fixtures/TimeSlot.js
@@ -29,6 +29,7 @@ const TimeSlot = new Factory()
     .set('hour', (index + 3) % 24)
     .toISOString())
   .attr('reserved', false)
-  .attr('resource', 'some-resource-id');
+  .attr('resource', 'some-resource-id')
+  .attr('onCooldown', false);
 
 export default TimeSlot;

--- a/app/utils/timeUtils.js
+++ b/app/utils/timeUtils.js
@@ -121,7 +121,9 @@ function getTimeSlots(
 
   const editRanges = map(
     reservationsToEdit, reservation => moment.range(
-      moment(reservation.begin), moment(reservation.end)
+      moment(reservation.begin), moment(reservation.end),
+      //      moment(reservation.begin).subtract(moment.duration(cooldown))
+
     )
   );
 
@@ -141,9 +143,10 @@ function getTimeSlots(
 
       const slotRange = moment.range(startMoment, endMoment);
       const editing = editRanges.some(editRange => editRange.overlaps(slotRange));
+      // const editingCooldown = editRanges.some(editRange => editRange.overlaps(cooldownRanges));
 
       let reserved = false;
-      let reservation = null;
+      let reservation = [];
       let reservationStarting = false;
       let reservationEnding = false;
       forEach(reservationRanges, (reservationRange, index) => {
@@ -161,12 +164,30 @@ function getTimeSlots(
         slot is on cooldown if it's within cooldown range
         slot is not on cooldown if it's set as reserved
       */
+      const isEditing = Boolean(reservationsToEdit.length);
       let onCooldown = false;
-      forEach(cooldownRanges, (cooldownRange) => {
+      forEach(cooldownRanges, (cooldownRange, index) => {
         if (!reserved && cooldownRange.overlaps(slotRange)) {
-          onCooldown = true;
+          //         reservation = reservations[index];
+          //         reservation = reservations[index];
+
+          reservation.push(reservations[index]);
+
+          if (isEditing) {
+            if (reservation.some(res => !res.isOwn) && isEditing) {
+              if (reservationRanges.some(resRange => resRange.overlaps(slotRange))) {
+                onCooldown = true;
+              }
+              onCooldown = true;
+            } else {
+              onCooldown = false;
+            }
+          } else {
+            onCooldown = true;
+          }
         }
       });
+
 
       return {
         asISOString,

--- a/app/utils/timeUtils.js
+++ b/app/utils/timeUtils.js
@@ -122,8 +122,6 @@ function getTimeSlots(
   const editRanges = map(
     reservationsToEdit, reservation => moment.range(
       moment(reservation.begin), moment(reservation.end),
-      //      moment(reservation.begin).subtract(moment.duration(cooldown))
-
     )
   );
 
@@ -143,7 +141,6 @@ function getTimeSlots(
 
       const slotRange = moment.range(startMoment, endMoment);
       const editing = editRanges.some(editRange => editRange.overlaps(slotRange));
-      // const editingCooldown = editRanges.some(editRange => editRange.overlaps(cooldownRanges));
 
       let reserved = false;
       let reservation = [];
@@ -161,23 +158,25 @@ function getTimeSlots(
       });
 
       /*
-        slot is on cooldown if it's within cooldown range
-        slot is not on cooldown if it's set as reserved
+        slot is on cooldown if it's within cooldown range of a reservation,
+        slot is not on cooldown if it's set as reserved.
+        When a slot is within cooldown range of a reservation it gets added to the slot,
+        if slot is within cooldown range of two reservations both are added.
+        The cooldown slots get a reservation but are NOT set as reserved.
+
+        When editing a reservation,
+        the cooldown slots that ONLY have the users reservation are false.
+        If a cooldown slots reservation is NOT
+        the users or its shared with another reservation it remains true.
       */
       const isEditing = Boolean(reservationsToEdit.length);
       let onCooldown = false;
       forEach(cooldownRanges, (cooldownRange, index) => {
         if (!reserved && cooldownRange.overlaps(slotRange)) {
-          //         reservation = reservations[index];
-          //         reservation = reservations[index];
-
           reservation.push(reservations[index]);
 
           if (isEditing) {
             if (reservation.some(res => !res.isOwn)) {
-              /*        if (reservationRanges.some(resRange => resRange.overlaps(slotRange))) {
-                onCooldown = true;
-              } */
               onCooldown = true;
             } else {
               onCooldown = false;

--- a/app/utils/timeUtils.js
+++ b/app/utils/timeUtils.js
@@ -174,10 +174,10 @@ function getTimeSlots(
           reservation.push(reservations[index]);
 
           if (isEditing) {
-            if (reservation.some(res => !res.isOwn) && isEditing) {
-              if (reservationRanges.some(resRange => resRange.overlaps(slotRange))) {
+            if (reservation.some(res => !res.isOwn)) {
+              /*        if (reservationRanges.some(resRange => resRange.overlaps(slotRange))) {
                 onCooldown = true;
-              }
+              } */
               onCooldown = true;
             } else {
               onCooldown = false;


### PR DESCRIPTION
Added reservation cooldown for the resource page. If a resource has a cooldown then the timeslots that are within the cooldownrange are disabled for a normal user, if editing a reservation for a resource with a cooldown then all timeslots that are ONLY connected to the users reservations are disabled. If the user is logged in as an admin then none of the restrictions apply, the cooldown timeslots can still be identified  by the hourglass icon on the timeslot.