### PR TITLE
Reservation form whitespace

### DIFF
--- a/app/actions/reservationActions.js
+++ b/app/actions/reservationActions.js
@@ -1,6 +1,7 @@
 import types from 'constants/ActionTypes';
 
 import pickBy from 'lodash/pickBy';
+import mapValues from 'lodash/mapValues';
 import { decamelizeKeys } from 'humps';
 import { RSAA } from 'redux-api-middleware';
 
@@ -84,8 +85,20 @@ function fetchReservations(params = {}) {
   };
 }
 
+/**
+ * Trims, parses and returns given reservation values in JSON form.
+ * @param {Object} reservation reservation values
+ * @returns reservation values in JSON form
+ */
 function parseReservationData(reservation) {
-  const parsed = pickBy(reservation, value => value || value === 0 || typeof (value) === 'boolean');
+  const trimmedValues = mapValues(reservation, (value) => {
+    if (typeof (value) === 'string') {
+      return value.trim();
+    }
+    return value;
+  });
+
+  const parsed = pickBy(trimmedValues, value => value || value === 0 || typeof (value) === 'boolean');
   return JSON.stringify(decamelizeKeys(parsed));
 }
 

--- a/app/pages/reservation/ReservationPage.js
+++ b/app/pages/reservation/ReservationPage.js
@@ -109,6 +109,12 @@ class UnconnectedReservationPage extends Component {
     window.scrollTo(0, 0);
   };
 
+  /**
+   * Calls redux post reservation action if making a new reservation or
+   * put reservation action if editing a previously made reservation.
+   *
+   * @param {Object} values each form field's values
+   */
   handleReservation = (values = {}) => {
     const {
       actions, currentLanguage, reservationToEdit, resource, selected
@@ -119,10 +125,22 @@ class UnconnectedReservationPage extends Component {
       const preferredLanguage = currentLanguage;
 
       if (!isEmpty(reservationToEdit)) {
-        const reservation = Object.assign({}, reservationToEdit);
+        // old reservation values before editing
+        const oldValues = Object.assign({}, reservationToEdit);
+        // new reservation values from each field
+        const newValues = Object.assign({}, values);
+        // if value (string) was not previously empty and now is empty -> insert "-"
+        for (let i = 0; i < Object.keys(newValues).length; i += 1) {
+          const key = Object.keys(newValues)[i];
+          if (typeof (oldValues[key]) === 'string' && oldValues[key].length > 0
+          && typeof (values[key]) === 'string' && values[key].trim().length === 0) {
+            newValues[key] = '-';
+          }
+        }
+
         actions.putReservation({
-          ...reservation,
-          ...values,
+          ...oldValues,
+          ...newValues,
           preferredLanguage,
           begin,
           end,

--- a/app/pages/reservation/ReservationPage.spec.js
+++ b/app/pages/reservation/ReservationPage.spec.js
@@ -500,10 +500,11 @@ describe('pages/reservation/ReservationPage', () => {
     const putReservation = simple.mock();
     const values = {
       someField: 'some value',
+      comments: '',
     };
 
     test('calls putReservation action when reservationToEdit not empty', () => {
-      const reservationToEdit = Reservation.build();
+      const reservationToEdit = Reservation.build({ comments: 'some comment' });
       const instance = getWrapper({
         actions: {
           postReservation,
@@ -515,6 +516,8 @@ describe('pages/reservation/ReservationPage', () => {
       expect(postReservation.callCount).toBe(0);
       expect(putReservation.callCount).toBe(1);
       expect(putReservation.lastCall.args[0].preferredLanguage).toEqual('fi');
+      expect(putReservation.lastCall.args[0].comments).toEqual('-');
+      expect(putReservation.lastCall.args[0].someField).toEqual(values.someField);
     });
 
     test('calls postReservation action when reservationToEdit empty', () => {

--- a/app/pages/reservation/reservation-information/ReservationInformationForm.js
+++ b/app/pages/reservation/reservation-information/ReservationInformationForm.js
@@ -63,7 +63,8 @@ export function validate(values, { fields, requiredFields, t }) {
       }
     }
     if (includes(currentRequiredFields, field)) {
-      if (!values[field]) {
+      // required fields cant be empty or have only white space in them
+      if (!values[field] || (typeof (values[field]) === 'string' && values[field].trim().length === 0)) {
         errors[field] = (
           field === 'termsAndConditions'
             ? t('ReservationForm.termsAndConditionsError')

--- a/app/pages/reservation/reservation-information/ReservationInformationForm.spec.js
+++ b/app/pages/reservation/reservation-information/ReservationInformationForm.spec.js
@@ -89,6 +89,17 @@ describe('pages/reservation/reservation-information/ReservationInformationForm',
         const errors = validate(values, props);
         expect(errors.name).toBeFalsy();
       });
+
+      test('returns an error if value is string and contains only white space', () => {
+        const props = {
+          fields: ['name'],
+          requiredFields: ['name'],
+          t,
+        };
+        const values = { name: '' };
+        const errors = validate(values, props);
+        expect(errors.name).toBeDefined();
+      });
     });
 
     describe('reserverEmailAddress', () => {

--- a/app/shared/modals/reservation-info/ReservationInfoModal.js
+++ b/app/shared/modals/reservation-info/ReservationInfoModal.js
@@ -30,7 +30,11 @@ class ReservationInfoModal extends Component {
 
   handleSaveCommentsClick() {
     const comments = this.commentsInput.value;
-    this.props.onSaveCommentsClick(comments);
+    if (typeof (comments) === 'string' && comments.trim().length === 0) {
+      this.props.onSaveCommentsClick('-');
+    } else {
+      this.props.onSaveCommentsClick(comments);
+    }
   }
 
   render() {

--- a/app/shared/modals/reservation-info/ReservationInfoModal.spec.js
+++ b/app/shared/modals/reservation-info/ReservationInfoModal.spec.js
@@ -367,22 +367,24 @@ describe('shared/modals/reservation-info/ReservationInfoModal', () => {
 
   describe('handleSaveCommentsClick', () => {
     const onSaveCommentsClick = simple.mock();
-    const comments = 'Updated comments';
+    const instance = getWrapper({ onSaveCommentsClick }).instance();
 
-    beforeAll(() => {
-      const instance = getWrapper({ onSaveCommentsClick }).instance();
-      // override ref value to mock
-      instance.commentsInput = { value: comments };
-      instance.handleSaveCommentsClick();
-    });
+    describe('calls onSaveCommentsClick with correct comments', () => {
+      test('when comments is not an empty string', () => {
+        const comments = 'Updated comments';
+        instance.commentsInput = { value: comments };
+        instance.handleSaveCommentsClick();
+        expect(onSaveCommentsClick.callCount).toBe(1);
+        expect(onSaveCommentsClick.lastCall.args).toEqual([comments]);
+      });
 
-    afterAll(() => {
-      simple.restore();
-    });
-
-    test('calls onSaveCommentsClick with correct comments', () => {
-      expect(onSaveCommentsClick.callCount).toBe(1);
-      expect(onSaveCommentsClick.lastCall.args).toEqual([comments]);
+      test('when comments is an empty string', () => {
+        const comments = ' ';
+        instance.commentsInput = { value: comments };
+        instance.handleSaveCommentsClick();
+        expect(onSaveCommentsClick.callCount).toBe(2);
+        expect(onSaveCommentsClick.lastCall.args).toEqual(['-']);
+      });
     });
   });
 });

--- a/app/shared/reservation-confirmation/ReservationConfirmationContainer.js
+++ b/app/shared/reservation-confirmation/ReservationConfirmationContainer.js
@@ -37,9 +37,23 @@ export class UnconnectedReservationConfirmationContainer extends Component {
 
   handleEdit = (values = {}) => {
     const { actions, reservationsToEdit } = this.props;
+
+    // old reservation values before editing
+    const oldValues = Object.assign({}, reservationsToEdit[0]);
+    // new reservation values from each field
+    const newValues = Object.assign({}, values);
+    // if value (string) was not previously empty and now is empty -> insert "-"
+    for (let i = 0; i < Object.keys(newValues).length; i += 1) {
+      const key = Object.keys(newValues)[i];
+      if (typeof (oldValues[key]) === 'string' && oldValues[key].length > 0
+      && typeof (values[key]) === 'string' && values[key].trim().length === 0) {
+        newValues[key] = '-';
+      }
+    }
+
     actions.putReservation({
-      ...reservationsToEdit[0],
-      ...values,
+      ...oldValues,
+      ...newValues,
     });
   }
 

--- a/app/shared/reservation-confirmation/ReservationConfirmationContainer.spec.js
+++ b/app/shared/reservation-confirmation/ReservationConfirmationContainer.spec.js
@@ -73,11 +73,11 @@ describe('pages/resource/reservation-calendar/ReservationConfirmationContainer',
 
   describe('handleEdit', () => {
     test('edits the selected reservation', () => {
-      const reservationsToEdit = [Reservation.build()];
+      const reservationsToEdit = [Reservation.build({ comments: 'some comment' })];
       const instance = getWrapper({ reservationsToEdit }).instance();
-      const newValues = { begin: 'foo', end: 'bar' };
+      const newValues = { begin: 'foo', end: 'bar', comments: '' };
       instance.handleEdit(newValues);
-      const expectedArgs = [{ ...reservationsToEdit[0], ...newValues }];
+      const expectedArgs = [{ ...reservationsToEdit[0], ...newValues, comments: '-' }];
       expect(defaultProps.actions.putReservation.callCount).toBe(1);
       expect(defaultProps.actions.putReservation.lastCall.args).toEqual(expectedArgs);
     });

--- a/app/shared/reservation-confirmation/ReservationForm.js
+++ b/app/shared/reservation-confirmation/ReservationForm.js
@@ -65,7 +65,8 @@ export function validate(values, { fields, requiredFields, t }) {
       }
     }
     if (includes(currentRequiredFields, field)) {
-      if (!values[field]) {
+      // required fields cant be empty or have only white space in them
+      if (!values[field] || (typeof (values[field]) === 'string' && values[field].trim().length === 0)) {
         errors[field] = (
           field === 'termsAndConditions'
             ? t('ReservationForm.termsAndConditionsError')

--- a/app/shared/reservation-confirmation/ReservationForm.spec.js
+++ b/app/shared/reservation-confirmation/ReservationForm.spec.js
@@ -86,6 +86,17 @@ describe('shared/reservation-confirmation/ReservationForm', () => {
         const errors = validate(values, props);
         expect(errors.name).toBeFalsy();
       });
+
+      test('returns an error if value is string and contains only white space', () => {
+        const props = {
+          fields: ['name'],
+          requiredFields: ['name'],
+          t,
+        };
+        const values = { name: '' };
+        const errors = validate(values, props);
+        expect(errors.name).toBeDefined();
+      });
     });
 
     describe('reserverEmailAddress', () => {


### PR DESCRIPTION
Most notable changes:
- reservation form required fields with only white space in them no longer pass validation.
- previously made non empty reservation form fields can be edited to be empty, resulting in "-" field value.