### PR TITLE
Added clearReservations

### DIFF
--- a/app/pages/admin-resources/AdminResourcesPage.js
+++ b/app/pages/admin-resources/AdminResourcesPage.js
@@ -11,6 +11,7 @@ import {
   selectAdminResourceType,
   openConfirmReservationModal,
   unselectAdminResourceType,
+  clearReservations,
 } from 'actions/uiActions';
 import { injectT } from 'i18n';
 import PageWrapper from 'pages/PageWrapper';
@@ -30,6 +31,8 @@ class UnconnectedAdminResourcesPage extends Component {
   }
 
   componentDidMount() {
+    // clearReservations called to make sure that redux ui.reservations is empty
+    this.props.actions.clearReservations();
     const interval = 10 * 60 * 1000;
     this.fetchResources();
     this.updateResourcesTimer = window.setInterval(this.fetchResources, interval);
@@ -134,6 +137,7 @@ function mapDispatchToProps(dispatch) {
   const actionCreators = {
     changeAdminResourcesPageDate,
     changeRecurringBaseTime: recurringReservations.changeBaseTime,
+    clearReservations,
     fetchFavoritedResources,
     selectAdminResourceType,
     openConfirmReservationModal,

--- a/app/pages/admin-resources/AdminResourcesPage.spec.js
+++ b/app/pages/admin-resources/AdminResourcesPage.spec.js
@@ -10,6 +10,7 @@ import { UnconnectedAdminResourcesPage as AdminResourcesPage } from './AdminReso
 
 describe('pages/admin-resources/AdminResourcesPage', () => {
   const changeAdminResourcesPageDate = simple.stub();
+  const clearReservations = simple.stub();
   const fetchFavoritedResources = simple.stub();
   const selectAdminResourceType = simple.stub();
   const openConfirmReservationModal = simple.stub();
@@ -19,6 +20,7 @@ describe('pages/admin-resources/AdminResourcesPage', () => {
     actions: {
       changeAdminResourcesPageDate,
       changeRecurringBaseTime: () => null,
+      clearReservations,
       fetchFavoritedResources,
       selectAdminResourceType,
       openConfirmReservationModal,
@@ -134,6 +136,7 @@ describe('pages/admin-resources/AdminResourcesPage', () => {
       let instance;
 
       beforeAll(() => {
+        clearReservations.reset();
         fetchFavoritedResources.reset();
         simple.mock(window, 'setInterval').returnWith(timer);
         instance = getWrapper({ isAdmin }).instance();
@@ -166,6 +169,10 @@ describe('pages/admin-resources/AdminResourcesPage', () => {
 
       test('saves interval to this.updateResourcesTimer', () => {
         expect(instance.updateResourcesTimer).toBe(timer);
+      });
+
+      test('clears redux state.ui.reservations', () => {
+        expect(clearReservations.callCount).toBe(1);
       });
     });
   });


### PR DESCRIPTION
added clearReservations to make sure that redux state.ui.reservations is empty. Previously if one started editing a reservation on the resourcepage without canceling or completing it, state.ui.reservations didnt get cleared and caused the admin-resources page to show wrong reservation state texts.