### PR TITLE
Feature/var38 text link naming

### DIFF
--- a/app/constants/AppConstants.js
+++ b/app/constants/AppConstants.js
@@ -24,7 +24,7 @@ export default {
     hidden: false,
   },
   REGEX: {
-    namedLink: /(\[.*?\]\(.*?(?!\[\]\(\))*?\))/gm
+    namedLink: /(\[[^[\]]*?\]\(.*?(?!\[\]\(\))*?\))/gm
   },
   REQUIRED_API_HEADERS: {
     Accept: 'application/json',

--- a/app/constants/AppConstants.js
+++ b/app/constants/AppConstants.js
@@ -23,6 +23,9 @@ export default {
     timeOut: 5000,
     hidden: false,
   },
+  REGEX: {
+    namedLink: /(\[.*?\]\(.*?(?!\[\]\(\))*?\))/gm
+  },
   REQUIRED_API_HEADERS: {
     Accept: 'application/json',
     'Accept-Language': 'fi',

--- a/app/pages/reservation/reservation-information/ReservationInformationForm.js
+++ b/app/pages/reservation/reservation-information/ReservationInformationForm.js
@@ -256,7 +256,14 @@ class UnconnectedReservationInformationForm extends Component {
             && <h3 id="additional-info-heading">{t('common.additionalInfo.heading')}</h3>
           }
           {includes(this.props.fields, 'reservationExtraQuestions')
-            && <WrappedText id="additional-info-paragraph" openLinksInNewTab text={resource.reservationAdditionalInformation} />
+            && (
+            <WrappedText
+              allowNamedLinks
+              id="additional-info-paragraph"
+              openLinksInNewTab
+              text={resource.reservationAdditionalInformation}
+            />
+            )
           }
           {this.renderField(
             'reservationExtraQuestions',

--- a/app/pages/reservation/reservation-information/ReservationInformationForm.spec.js
+++ b/app/pages/reservation/reservation-information/ReservationInformationForm.spec.js
@@ -237,6 +237,7 @@ describe('pages/reservation/reservation-information/ReservationInformationForm',
           const wrappedText = wrapper.find('#additional-info-paragraph');
           expect(wrappedText.length).toBe(1);
           expect(wrappedText.prop('text')).toBe(resource.reservationAdditionalInformation);
+          expect(wrappedText.prop('allowNamedLinks')).toBeDefined();
           expect(wrappedText.prop('openLinksInNewTab')).toBeDefined();
         });
       });

--- a/app/pages/resource/reservation-info/ReservationInfo.js
+++ b/app/pages/resource/reservation-info/ReservationInfo.js
@@ -73,7 +73,7 @@ function renderMaxReservationsPerUserText(maxReservationsPerUser, t) {
 function ReservationInfo({ isLoggedIn, resource, t }) {
   return (
     <div className="app-ReservationInfo">
-      <WrappedText openLinksInNewTab text={resource.reservationInfo} />
+      <WrappedText allowNamedLinks openLinksInNewTab text={resource.reservationInfo} />
       {renderEarliestResDay(resource.reservableMinDaysInAdvance, t)}
       {renderMaxPeriodText(resource, t)}
       {renderMaxReservationsPerUserText(resource.maxReservationsPerUser, t)}

--- a/app/pages/resource/reservation-info/ReservationInfo.spec.js
+++ b/app/pages/resource/reservation-info/ReservationInfo.spec.js
@@ -34,6 +34,7 @@ describe('pages/resource/reservation-info/ReservationInfo', () => {
     const wrappedText = getWrapper().find(WrappedText);
     expect(wrappedText.length).toBe(1);
     expect(wrappedText.props().text).toBe(defaultProps.resource.reservationInfo);
+    expect(wrappedText.props().allowNamedLinks).toBe(true);
     expect(wrappedText.props().openLinksInNewTab).toBe(true);
   });
 

--- a/app/pages/resource/resource-info/ResourceInfo.js
+++ b/app/pages/resource/resource-info/ResourceInfo.js
@@ -21,7 +21,8 @@ function ResourceInfo({
       <section aria-labelledby="ResourcePageInfo" className="app-ResourceInfo">
         <h2 className="visually-hidden" id="ResourcePageInfo">{t('ResourcePage.info')}</h2>
         <div className="app-ResourceInfo__description">
-          {resource.description && <WrappedText openLinksInNewTab text={resource.description} />}
+          {resource.description
+          && <WrappedText allowNamedLinks openLinksInNewTab text={resource.description} />}
         </div>
         <Panel defaultExpanded header={t('ResourceInfo.reservationTitle')} id="reservation-panel" role="tablist">
           <Panel.Heading>

--- a/app/pages/resource/resource-info/ResourceInfo.spec.js
+++ b/app/pages/resource/resource-info/ResourceInfo.spec.js
@@ -56,6 +56,7 @@ describe('pages/resource/resource-info/ResourceInfo', () => {
 
     expect(wrappedText).toHaveLength(1);
     expect(wrappedText.prop('text')).toBe(expectedText);
+    expect(wrappedText.prop('allowNamedLinks')).toBe(true);
     expect(wrappedText.prop('openLinksInNewTab')).toBe(true);
   });
 

--- a/app/shared/modals/reservation-terms/ReservationTermsModal.js
+++ b/app/shared/modals/reservation-terms/ReservationTermsModal.js
@@ -36,7 +36,7 @@ class UnconnectedReservationTermsModal extends Component {
         <Modal.Body>
           <div>
             <span>{t('ReservationTermsModal.resourceTermsSubTitle', { name })}</span>
-            <span><WrappedText text={genericTerms} /></span>
+            <span><WrappedText allowNamedLinks openLinksInNewTab text={genericTerms} /></span>
           </div>
         </Modal.Body>
 

--- a/app/shared/modals/reservation-terms/ReservationTermsModal.spec.js
+++ b/app/shared/modals/reservation-terms/ReservationTermsModal.spec.js
@@ -72,6 +72,8 @@ describe('shared/modals/reservation-cancel/ReservationTermsModal', () => {
         const wrappedText = getModalBodyWrapper({ resource: resourceWithTerms }).find(WrappedText);
         expect(wrappedText).toHaveLength(1);
         expect(wrappedText.prop('text')).toBe(resourceWithTerms.genericTerms);
+        expect(wrappedText.prop('allowNamedLinks')).toBe(true);
+        expect(wrappedText.prop('openLinksInNewTab')).toBe(true);
       });
     });
 

--- a/app/shared/reservation-confirmation/ReservationForm.js
+++ b/app/shared/reservation-confirmation/ReservationForm.js
@@ -209,7 +209,12 @@ class UnconnectedReservationForm extends Component {
           {includes(this.props.fields, 'reservationExtraQuestions') && (
             <Well>
               <p id="additional-info-heading">{t('common.additionalInfo.heading')}</p>
-              <WrappedText id="additional-info-paragraph" openLinksInNewTab text={resource.reservationAdditionalInformation} />
+              <WrappedText
+                allowNamedLinks
+                id="additional-info-paragraph"
+                openLinksInNewTab
+                text={resource.reservationAdditionalInformation}
+              />
               {this.renderField(
                 'reservationExtraQuestions',
                 'textarea',
@@ -270,7 +275,7 @@ class UnconnectedReservationForm extends Component {
           {termsAndConditions && (
             <div className="terms-and-conditions">
               <h5>{t('ReservationForm.termsAndConditionsHeader')}</h5>
-              <WrappedText text={termsAndConditions} />
+              <WrappedText allowNamedLinks openLinksInNewTab text={termsAndConditions} />
             </div>
           )}
           {termsAndConditions && (

--- a/app/shared/reservation-confirmation/ReservationForm.spec.js
+++ b/app/shared/reservation-confirmation/ReservationForm.spec.js
@@ -225,6 +225,7 @@ describe('shared/reservation-confirmation/ReservationForm', () => {
           const wrappedText = wrapper.find('#additional-info-paragraph');
           expect(wrappedText.length).toBe(1);
           expect(wrappedText.prop('text')).toBe(resource.reservationAdditionalInformation);
+          expect(wrappedText.prop('allowNamedLinks')).toBeDefined();
           expect(wrappedText.prop('openLinksInNewTab')).toBeDefined();
         });
       });
@@ -265,6 +266,8 @@ describe('shared/reservation-confirmation/ReservationForm', () => {
 
             expect(wrappedText.length).toBe(1);
             expect(wrappedText.prop('text')).toBe(termsAndConditions);
+            expect(wrappedText.prop('allowNamedLinks')).toBeDefined();
+            expect(wrappedText.prop('openLinksInNewTab')).toBeDefined();
           }
         );
 

--- a/app/shared/wrapped-text/WrappedText.js
+++ b/app/shared/wrapped-text/WrappedText.js
@@ -24,7 +24,7 @@ function parseNamedLinks(text, linkAttributes) {
 
     if (textSplit.match(linkRegex)) {
       // find link name text between []
-      let linkText = textSplit.match(/(\[[^[\]()]*?\])/gm)[0];
+      let linkText = textSplit.match(/(\[[^[\]]*?\])/gm)[0];
       // remove []
       linkText = linkText.substring(1, linkText.length - 1);
 

--- a/app/shared/wrapped-text/WrappedText.js
+++ b/app/shared/wrapped-text/WrappedText.js
@@ -2,7 +2,55 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Linkify from 'react-linkify';
 
-function renderParagraph(text, index, openLinksInNewTab) {
+// matches content: "[text](url)"
+const linkRegex = /(\[[^[\]()]*?\]\(.*?(?!\[\]\(\))*?\))/gm;
+
+/**
+ * If text contains [text](url), replaces those parts with:
+ * <a href="url" {linkAttributes}>text</a>
+ * @param {string} text
+ * @param {Object} linkAttributes
+ * @returns an array that contains text and link elements
+ */
+function parseNamedLinks(text, linkAttributes) {
+  const textSplits = text.split(linkRegex);
+  const elements = textSplits.map((textSplit, index) => {
+    // dont handle undefined splits
+    if (textSplit === undefined) {
+      return null;
+    }
+
+    if (textSplit.match(linkRegex)) {
+      // find link name text between []
+      let linkText = textSplit.match(/(\[[^[\]()]*?\])/gm)[0];
+      // remove []
+      linkText = linkText.substring(1, linkText.length - 1);
+
+      // find link url text between ()
+      let linkUrl = textSplit.match(/(\(.*?(?!\[\]\(\))*?\))/gm)[0];
+      // remove ()
+      linkUrl = linkUrl.substring(1, linkUrl.length - 1);
+      return (
+        <a href={linkUrl} key={index} {...linkAttributes}>
+          {linkText}
+        </a>
+      );
+    }
+    return textSplit;
+  });
+
+  return elements;
+}
+
+/**
+ * Handles finding links within the given text string and returns the text
+ * converted into JSX text and link elements.
+ * @param {string} text input string to be converted into linkified JSX
+ * @param {number} index key value of the returned JSX element
+ * @param {boolean} openLinksInNewTab are generated links opened in new tabs
+ * @param {boolean} allowNamedLinks are named links converted into links
+ */
+function renderParagraph(text, index, openLinksInNewTab, allowNamedLinks) {
   const properties = openLinksInNewTab
     ? {
       rel: 'noopener noreferrer',
@@ -12,12 +60,16 @@ function renderParagraph(text, index, openLinksInNewTab) {
 
   return (
     <div key={index}>
-      <Linkify properties={properties}>{text}</Linkify>
+      <Linkify properties={properties}>
+        {allowNamedLinks ? parseNamedLinks(text, properties) : text}
+      </Linkify>
     </div>
   );
 }
 
-function WrappedText({ text, openLinksInNewTab = false }) {
+function WrappedText(
+  { text, openLinksInNewTab = false, allowNamedLinks = false }
+) {
   if (!text) {
     return <div />;
   }
@@ -25,7 +77,9 @@ function WrappedText({ text, openLinksInNewTab = false }) {
     <div className="wrapped-text">
       {text
         .split('\n')
-        .map((paragraph, index) => renderParagraph(paragraph, index, openLinksInNewTab))}
+        .map((paragraph, index) => renderParagraph(
+          paragraph, index, openLinksInNewTab, allowNamedLinks
+        ))}
     </div>
   );
 }
@@ -33,6 +87,7 @@ function WrappedText({ text, openLinksInNewTab = false }) {
 WrappedText.propTypes = {
   text: PropTypes.string,
   openLinksInNewTab: PropTypes.bool,
+  allowNamedLinks: PropTypes.bool,
 };
 
 export default WrappedText;

--- a/app/shared/wrapped-text/WrappedText.js
+++ b/app/shared/wrapped-text/WrappedText.js
@@ -1,9 +1,11 @@
+import constants from 'constants/AppConstants';
+
 import PropTypes from 'prop-types';
 import React from 'react';
 import Linkify from 'react-linkify';
 
 // matches content: "[text](url)"
-const linkRegex = /(\[[^[\]()]*?\]\(.*?(?!\[\]\(\))*?\))/gm;
+const linkRegex = constants.REGEX.namedLink;
 
 /**
  * If text contains [text](url), replaces those parts with:

--- a/app/shared/wrapped-text/WrappedText.spec.js
+++ b/app/shared/wrapped-text/WrappedText.spec.js
@@ -92,4 +92,24 @@ describe('shared/wrapped-text/WrappedText', () => {
       expect(linkify.props().properties.rel).toBe('noopener noreferrer');
     });
   });
+
+  describe('Named links', () => {
+    const text = 'Text and [named link](http://example.com/) and more text';
+    const expectedLink = <a href="http://example.com/" rel="noopener noreferrer" target="_blank">named link</a>;
+    let content;
+
+    test('are not supported by default', () => {
+      content = getWrapper({ text }).children();
+      const linkify = content.find(Linkify);
+      expect(linkify.length).toBe(1);
+      expect(linkify.children().contains(expectedLink)).toEqual(false);
+    });
+
+    test('are converted correctly when allowNamedLinks is true', () => {
+      content = getWrapper({ text, allowNamedLinks: true, openLinksInNewTab: true }).children();
+      const linkify = content.find(Linkify);
+      expect(linkify.length).toBe(1);
+      expect(linkify.children().contains(expectedLink)).toEqual(true);
+    });
+  });
 });


### PR DESCRIPTION
Most notable changes:

- Linkified texts support named links with following syntax: `[link name](url)`.
- Changed all current linkified texts to allow named links.