### PR TITLE
Search page resource card description named link cleansing

### DIFF
--- a/app/shared/resource-card/ResourceCard.js
+++ b/app/shared/resource-card/ResourceCard.js
@@ -20,6 +20,7 @@ import iconMap from 'assets/icons/map.svg';
 import BackgroundImage from 'shared/background-image';
 import { getMainImage } from 'utils/imageUtils';
 import { getHourlyPrice, getResourcePageUrlComponents } from 'utils/resourceUtils';
+import { cleanseNamedLinks } from 'utils/textUtils';
 import ResourceAvailability from './label';
 import ResourceCardInfoCell from './info';
 import resourceCardSelector from './resourceCardSelector';
@@ -62,11 +63,14 @@ class ResourceCard extends Component {
     if (text === null) {
       return '';
     }
-    if (text.length <= maxCharacters) {
-      return text;
+
+    const cleansedText = cleanseNamedLinks(text);
+
+    if (cleansedText.length <= maxCharacters) {
+      return cleansedText;
     }
 
-    return `${text.substring(0, maxCharacters)}...`;
+    return `${cleansedText.substring(0, maxCharacters)}...`;
   }
 
   renderDistance(distance) {

--- a/app/shared/resource-card/ResourceCard.spec.js
+++ b/app/shared/resource-card/ResourceCard.spec.js
@@ -414,6 +414,12 @@ describe('shared/resource-card/ResourceCard', () => {
       const testString = 'this is a test string';
       expect(instance.createTextSnippet(testString, 4)).toEqual('this...');
     });
+    test('if given string contains a named link, it is cleansed correctly', () => {
+      const instance = getWrapper().instance();
+      const testString = 'this is a test string with [named link](https://www.google.com)';
+      const expectedResult = 'this is a test string with named link';
+      expect(instance.createTextSnippet(testString, 100)).toEqual(expectedResult);
+    });
   });
 
   describe('handleSearchByType', () => {

--- a/app/utils/__tests__/textUtils.spec.js
+++ b/app/utils/__tests__/textUtils.spec.js
@@ -1,0 +1,14 @@
+import { cleanseNamedLinks } from 'utils/textUtils';
+
+describe('Utils: textUtils', () => {
+  describe('cleanseNamedLinks', () => {
+    test('replaces all named links with only the link names', () => {
+      const testText = 'text and [named link](https://www.google.com) and text again and [link](url)';
+      const expectedResult = 'text and named link and text again and link';
+      expect(cleanseNamedLinks(testText)).toEqual(expectedResult);
+    });
+    test('returns an empty string if the given text is an empty string', () => {
+      expect(cleanseNamedLinks('')).toEqual('');
+    });
+  });
+});

--- a/app/utils/textUtils.js
+++ b/app/utils/textUtils.js
@@ -1,0 +1,33 @@
+import constants from 'constants/AppConstants';
+
+/**
+  * Finds named link syntax within given text and replaces found
+  * strings with only the name of the link.
+  * @param {string} text input text to be cleansed
+  * @returns text where named links are replaced with their link names only.
+  */
+function cleanseNamedLinks(text) {
+  const linkRegex = constants.REGEX.namedLink;
+  const textSplits = text.split(linkRegex);
+  const elements = textSplits.map((textSplit) => {
+    // dont handle undefined splits
+    if (textSplit === undefined) {
+      return null;
+    }
+
+    if (textSplit.match(linkRegex)) {
+      // find link name text between []
+      let linkText = textSplit.match(/(\[[^[\]]*?\])/gm)[0];
+      // remove []
+      linkText = linkText.substring(1, linkText.length - 1);
+      return linkText;
+    }
+    return textSplit;
+  });
+
+  return elements.join('');
+}
+
+export {
+  cleanseNamedLinks,
+};


### PR DESCRIPTION
Resource card description snippets will convert named links into their link names only.
For example
`description text and [link name](https://www.google.com)`
converts into:
`description text and link name`


